### PR TITLE
Run our sqllogic tests in CI

### DIFF
--- a/.github/workflows/Rest.yml
+++ b/.github/workflows/Rest.yml
@@ -50,3 +50,13 @@ jobs:
         working-directory: scripts/
         run: |
           ./start-rest-catalog.sh
+
+      - name: Make debug
+        run: |
+          make debug
+
+      - name: Test debug
+        env:
+          DUCKDB_ICEBERG_HAVE_TEST_DATA: 1
+        run: |
+          make test_debug


### PR DESCRIPTION
Unsure if we want testing to happen in a separate yml file or not. I see that `make test_release` is already called in the extension distributions, but not with proper environment variables. Also there are many steps in there so I thought it might also be nice to have a workflow that is dedicated to just testing instead of building/testing/deploying